### PR TITLE
Add universal binary support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,8 +33,15 @@
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'OTHER_CFLAGS': [
+              '-arch x86_64',
+              '-arch arm64'
+            ],
             'OTHER_LDFLAGS': [
-              '-framework CoreFoundation -framework IOKit'
+              '-framework CoreFoundation',
+              '-framework IOKit',
+              '-arch x86_64',
+              '-arch arm64'
             ]
           }
         }


### PR DESCRIPTION
The gyp file had some missing flags to correctly create a universal binary for MacOS.

This means the current prebuild binaries won't work on Darwin Arm64 architecture (Apple M1)

This PR fixes the flags and all is well again.