### PR TITLE
Allow for RTS to be explicitly enabled

### DIFF
--- a/lib/win32.ts
+++ b/lib/win32.ts
@@ -8,7 +8,9 @@ const debug = debugFactory('serialport/bindings-cpp')
 
 export interface WindowsOpenOptions extends OpenOptions {
   /** Device parity defaults to none */
-  parity?: 'none' | 'even' | 'odd' | 'mark' |'space'
+  parity?: 'none' | 'even' | 'odd' | 'mark' |'space',
+  /** RTS mode defaults to handshake */
+  rtsMode?: 'handshake' | 'enable' | 'toggle'
 }
 
 export const WindowsBinding: BindingInterface<WindowsPortBinding, WindowsOpenOptions> = {
@@ -49,6 +51,7 @@ export const WindowsBinding: BindingInterface<WindowsPortBinding, WindowsOpenOpt
       stopBits: 1,
       parity: 'none',
       rtscts: false,
+      rtsMode: 'handshake',
       xon: false,
       xoff: false,
       xany: false,

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -61,7 +61,7 @@ Napi::Value Open(const Napi::CallbackInfo& info) {
   baton->parity = ToParityEnum(getStringFromObj(options, "parity"));
   baton->stopBits = ToStopBitEnum(getDoubleFromObject(options, "stopBits"));
   baton->rtscts = getBoolFromObject(options, "rtscts");
-  baton->rtshs = getBoolFromObject(options, "rtshs");
+  baton->rtsMode = ToRtsModeEnum(getStringFromObj(options, "rtsMode"));
   baton->xon = getBoolFromObject(options, "xon");
   baton->xoff = getBoolFromObject(options, "xoff");
   baton->xany = getBoolFromObject(options, "xany");
@@ -297,6 +297,22 @@ inline SerialPortParity ToParityEnum(const Napi::String& napistr) {
     return SERIALPORT_STOPBITS_TWO;
   }
   return SERIALPORT_STOPBITS_ONE;
+}
+
+inline SerialPortRtsMode ToRtsModeEnum(const Napi::String& napistr) {
+  auto tmp = napistr.Utf8Value();
+  const char* str = tmp.c_str();
+
+  size_t count = strlen(str);
+  SerialPortRtsMode mode = SERIALPORT_RTSMODE_HANDSHAKE;
+  if (!strncasecmp(str, "enable", count)) {
+    mode = SERIALPORT_RTSMODE_ENABLE;
+  } else if (!strncasecmp(str, "handshake", count)) {
+    mode = SERIALPORT_RTSMODE_HANDSHAKE;
+  } else if (!strncasecmp(str, "toggle", count)) {
+    mode = SERIALPORT_RTSMODE_TOGGLE;
+  }
+  return mode;
 }
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -61,6 +61,7 @@ Napi::Value Open(const Napi::CallbackInfo& info) {
   baton->parity = ToParityEnum(getStringFromObj(options, "parity"));
   baton->stopBits = ToStopBitEnum(getDoubleFromObject(options, "stopBits"));
   baton->rtscts = getBoolFromObject(options, "rtscts");
+  baton->rtshs = getBoolFromObject(options, "rtshs");
   baton->xon = getBoolFromObject(options, "xon");
   baton->xoff = getBoolFromObject(options, "xoff");
   baton->xany = getBoolFromObject(options, "xany");

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -49,7 +49,7 @@ enum SerialPortStopBits {
 enum SerialPortRtsMode {
   SERIALPORT_RTSMODE_ENABLE     = 1,
   SERIALPORT_RTSMODE_HANDSHAKE  = 2,
-  SERIALPORT_RTSMODE_TOGGLE    = 3
+  SERIALPORT_RTSMODE_TOGGLE     = 3
 };
 
 SerialPortParity ToParityEnum(const Napi::String& str);

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -59,6 +59,7 @@ struct OpenBaton : public Napi::AsyncWorker {
   int baudRate = 0;
   int dataBits = 0;
   bool rtscts = false;
+  bool rtshs = true;
   bool xon = false;
   bool xoff = false;
   bool xany = false;

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -46,8 +46,15 @@ enum SerialPortStopBits {
   SERIALPORT_STOPBITS_TWO      = 3
 };
 
+enum SerialPortRtsMode {
+  SERIALPORT_RTSMODE_ENABLE     = 1,
+  SERIALPORT_RTSMODE_HANDSHAKE  = 2,
+  SERIALPORT_RTSMODE_TOGGLE    = 3
+};
+
 SerialPortParity ToParityEnum(const Napi::String& str);
 SerialPortStopBits ToStopBitEnum(double stopBits);
+SerialPortRtsMode ToRtsModeEnum(const Napi::String& str);
 
 struct OpenBaton : public Napi::AsyncWorker {
   OpenBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:OpenBaton"),
@@ -59,7 +66,6 @@ struct OpenBaton : public Napi::AsyncWorker {
   int baudRate = 0;
   int dataBits = 0;
   bool rtscts = false;
-  bool rtshs = true;
   bool xon = false;
   bool xoff = false;
   bool xany = false;
@@ -67,6 +73,7 @@ struct OpenBaton : public Napi::AsyncWorker {
   bool lock = false;
   SerialPortParity parity;
   SerialPortStopBits stopBits;
+  SerialPortRtsMode rtsMode;
 #ifndef WIN32
   uint8_t vmin = 0;
   uint8_t vtime = 0;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -122,7 +122,11 @@ void OpenBaton::Execute() {
   }
 
   if (rtscts) {
-    dcb.fRtsControl = RTS_CONTROL_HANDSHAKE;
+    if (rtshs) {
+      dcb.fRtsControl = RTS_CONTROL_HANDSHAKE;
+    } else {
+      dcb.fRtsControl = RTS_CONTROL_ENABLE;
+    }
     dcb.fOutxCtsFlow = TRUE;
   } else {
     dcb.fRtsControl = RTS_CONTROL_DISABLE;

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -122,10 +122,16 @@ void OpenBaton::Execute() {
   }
 
   if (rtscts) {
-    if (rtshs) {
-      dcb.fRtsControl = RTS_CONTROL_HANDSHAKE;
-    } else {
-      dcb.fRtsControl = RTS_CONTROL_ENABLE;
+    switch (rtsMode) {
+      case SERIALPORT_RTSMODE_ENABLE:
+        dcb.fRtsControl = RTS_CONTROL_ENABLE;
+        break;
+      case SERIALPORT_RTSMODE_HANDSHAKE:
+        dcb.fRtsControl = RTS_CONTROL_HANDSHAKE;
+        break;
+      case SERIALPORT_RTSMODE_TOGGLE:
+        dcb.fRtsControl = RTS_CONTROL_TOGGLE;
+        break;
     }
     dcb.fOutxCtsFlow = TRUE;
   } else {


### PR DESCRIPTION
Discovered in relation to https://github.com/serialport/node-serialport/issues/2381.

I have an older device which requires that the RTS line is always enabled. As part of https://github.com/serialport/bindings-cpp/commit/cd112ca5a3a3fe186e1ac6fa78eeeb5ea7396185, the behavior of `rtscts: true` on Windows shifted from `RTS_CONTROL_ENABLE` to `RTS_CONTROL_HANDSHAKE`, which broke communication with my device.

This PR adds a new option to the OpenBaton: "`rtshs`", which controls whether `rtscts` uses `RTS_CONTROL_HANDSHAKE` (`rtshs=true`) or `RTS_CONTROL_ENABLE` (`rtshs=false`).

The value defaults to `true` so the behavior remains unchanged unless something like the following is used when instantiating the port:

```
const port = new SerialPort(path, {
  rtscts: true,
  rtshs: false
});
```
