### PR TITLE
allow to set rts/dtr/brk/cts/dsr seperately for windows

### DIFF
--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -32,6 +32,17 @@ double getDoubleFromObject(Napi::Object options, std::string key) {
   return getValueFromObject(options, key).ToNumber().DoubleValue();
 }
 
+bool hasKeyWithDefinedValue(Napi::Object options, std::string key) {
+  if ((options).Has(key)) {
+    Napi::Value val = getValueFromObject(options, key);
+    if (val.IsUndefined() || val.IsNull()) {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
 Napi::Value Open(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   // path
@@ -184,11 +195,26 @@ Napi::Value Set(const Napi::CallbackInfo& info) {
 
   SetBaton* baton = new SetBaton(callback);
   baton->fd = fd;
-  baton->brk = getBoolFromObject(options, "brk");
-  baton->rts = getBoolFromObject(options, "rts");
-  baton->cts = getBoolFromObject(options, "cts");
-  baton->dtr = getBoolFromObject(options, "dtr");
-  baton->dsr = getBoolFromObject(options, "dsr");
+  if (hasKeyWithDefinedValue(options, "brk")) {
+    baton->brkToSet = true;
+    baton->brk = getBoolFromObject(options, "brk");
+  }
+  if (hasKeyWithDefinedValue(options, "rts")) {
+    baton->rtsToSet = true;
+    baton->rts = getBoolFromObject(options, "rts");
+  }
+  if (hasKeyWithDefinedValue(options, "cts")) {
+    baton->ctsToSet = true;
+    baton->cts = getBoolFromObject(options, "cts");
+  }
+  if (hasKeyWithDefinedValue(options, "dtr")) {
+    baton->dtrToSet = true;
+    baton->dtr = getBoolFromObject(options, "dtr");
+  }
+  if (hasKeyWithDefinedValue(options, "dsr")) {
+    baton->rtsToSet = true;
+    baton->dsr = getBoolFromObject(options, "dsr");
+  }
   baton->lowLatency = getBoolFromObject(options, "lowLatency");
 
   baton->Queue();

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -118,6 +118,12 @@ struct SetBaton : public Napi::AsyncWorker {
   bool brk = false;
   bool lowLatency = false;
 
+  bool rtsToSet = false;
+  bool dtrToSet = false;
+  bool brkToSet = false;
+  bool ctsToSet = false;
+  bool dsrToSet = false;
+
   void Execute() override;
 
   void OnOK() override {

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -223,22 +223,32 @@ void ConnectionOptionsBaton::Execute() {
 }
 
 void SetBaton::Execute() {
-  if (rts) {
-    EscapeCommFunction(int2handle(fd), SETRTS);
-  } else {
-    EscapeCommFunction(int2handle(fd), CLRRTS);
+  if (rtsToSet) {
+    if (rts) {
+      EscapeCommFunction(int2handle(fd), SETRTS);
+    } else {
+      EscapeCommFunction(int2handle(fd), CLRRTS);
+    }
   }
 
-  if (dtr) {
-    EscapeCommFunction(int2handle(fd), SETDTR);
-  } else {
-    EscapeCommFunction(int2handle(fd), CLRDTR);
+  if (dtrToSet) {
+    if (dtr) {
+      EscapeCommFunction(int2handle(fd), SETDTR);
+    } else {
+      EscapeCommFunction(int2handle(fd), CLRDTR);
+    }
   }
 
-  if (brk) {
-    EscapeCommFunction(int2handle(fd), SETBREAK);
-  } else {
-    EscapeCommFunction(int2handle(fd), CLRBREAK);
+  if (brkToSet) {
+    if (brk) {
+      EscapeCommFunction(int2handle(fd), SETBREAK);
+    } else {
+      EscapeCommFunction(int2handle(fd), CLRBREAK);
+    }
+  }
+
+  if (!ctsToSet && !dsrToSet) {
+    return;
   }
 
   DWORD bits = 0;


### PR DESCRIPTION
This PR allows to set rts/dtr/brk/cts/dsr seperately for windows. It will always set a true/false value for these signals when using `set` function, which will triggle multiple `EscapeCommFunction` on windows. It will cause issues in some corner cases. For exmaple, in the esp32 flash logic, it needs to use rts and cts to control the IO signals, when using this library, the extra `EscapeCommFunction` will make the signal a little longer and it will fail to enter download mode. I've fixed it if we can set them seperately, please review the details in this PR. Thanks.