### PR TITLE
feat: build and ship ESM js files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 prebuilds
 .tool-versions
 dist
+dist-esm

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "SerialPort Hardware bindings for node serialport written in c++",
   "version": "0.0.0-development",
   "main": "./dist/index.js",
+  "module": "./dist-esm/index.js",
   "types": "./dist/index.d.ts",
   "keywords": [
     "serialport-binding",
@@ -55,7 +56,7 @@
     "node": ">=12.17.0 <13.0 || >=14.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig-build.json",
+    "build": "rm -rf dist dist-esm && tsc -p tsconfig-build.json && tsc -p tsconfig-build-esm.json",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --target 14.0.0 --force --strip --verbose",
     "prebuildify-cross": "prebuildify-cross --napi --target 14.0.0 --force --strip --verbose",

--- a/tsconfig-build-esm.json
+++ b/tsconfig-build-esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig-build.json",
+  "compilerOptions": {
+    "outDir": "dist-esm",
+    "module": "ES2022"
+  }
+}


### PR DESCRIPTION
This adds a simple second tsconfig that has `module: ES2022` and the required `module` field in the package.json so that bundlers like webpack can find it.

This is required in order for this package to work with [`@vercel/webpack-asset-relocator-loader`](https://github.com/vercel/webpack-asset-relocator-loader) which is a pre-requisite to using this module in certain webpack deployment environments (electron, single-package-executables, etc.)

I specifically chose to ship `dist-esm` instead of `dist/cjs` and `dist/esm` to avoid path resolution changes 🤷 

Refs: https://github.com/electron/forge/issues/2949
Refs: https://github.com/vercel/webpack-asset-relocator-loader/pull/168