### PR TITLE
Fix unsupported architecture for MacOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,11 +33,11 @@
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'MACOSX_DEPLOYMENT_TARGET': '10.9',
-            'OTHER_CFLAGS': [
+            'CFLAGS': [
               '-arch x86_64',
               '-arch arm64'
             ],
-            'OTHER_LDFLAGS': [
+            'LDFLAGS': [
               '-framework CoreFoundation',
               '-framework IOKit',
               '-arch x86_64',


### PR DESCRIPTION
Hi,

With `OTHER_` prefix my macos is not able to build the module with node-gyp. With this fix it is able to build. :)

fix: #99 