### PR TITLE
fix: update build tools and fix arm64 build for rpi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           - name: linux-arm
             os: ubuntu-latest
             command: prebuildify-cross
-            args: -i linux-arm64 -i linux-armv7 -i linux-armv6
+            args: -i linux-arm64-lts -i linux-armv7 -i linux-armv6
           - name: android-arm
             os: ubuntu-latest
             command: prebuildify-cross

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'openssl_fips': ''
+  },
   'targets': [{
     'target_name': 'bindings',
     'sources': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "@serialport/bindings-interface": "1.2.2",
         "@serialport/parser-readline": "^10.2.1",
         "debug": "^4.3.2",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.3.0"
+        "node-addon-api": "6.0.0",
+        "node-gyp-build": "4.6.0"
       },
       "devDependencies": {
         "@semantic-release/exec": "6.0.3",
@@ -34,7 +34,7 @@
         "eslint": "8.38.0",
         "mocha": "10.2.0",
         "node-abi": "3.40.0",
-        "node-gyp": "9.3.0",
+        "node-gyp": "9.3.1",
         "nyc": "15.1.0",
         "prebuildify": "5.0.1",
         "prebuildify-cross": "5.0.0",
@@ -44,7 +44,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": ">=12.17.0 <13.0 || >=14.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
@@ -7352,9 +7352,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
+      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
@@ -7408,9 +7408,9 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.0.tgz",
-      "integrity": "sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.1.tgz",
+      "integrity": "sha512-4Q16ZCqq3g8awk6UplT7AuxQ35XN4R/yf/+wSAwcBUAjg7l58RTactWaP8fIDTi0FzI7YcVLujwExakZlfWkXg==",
       "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -7428,13 +7428,13 @@
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
+        "node": "^12.13 || ^14.13 || >=16"
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -18785,9 +18785,9 @@
       }
     },
     "node-addon-api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
+      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
     },
     "node-emoji": {
       "version": "1.11.0",
@@ -18832,9 +18832,9 @@
       }
     },
     "node-gyp": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.0.tgz",
-      "integrity": "sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.3.1.tgz",
+      "integrity": "sha512-4Q16ZCqq3g8awk6UplT7AuxQ35XN4R/yf/+wSAwcBUAjg7l58RTactWaP8fIDTi0FzI7YcVLujwExakZlfWkXg==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
@@ -18850,9 +18850,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-preload": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@serialport/bindings-interface": "1.2.2",
     "@serialport/parser-readline": "^10.2.1",
     "debug": "^4.3.2",
-    "node-addon-api": "^5.0.0",
-    "node-gyp-build": "^4.3.0"
+    "node-addon-api": "6.0.0",
+    "node-gyp-build": "4.6.0"
   },
   "devDependencies": {
     "@semantic-release/exec": "6.0.3",
@@ -42,7 +42,7 @@
     "eslint": "8.38.0",
     "mocha": "10.2.0",
     "node-abi": "3.40.0",
-    "node-gyp": "9.3.0",
+    "node-gyp": "9.3.1",
     "nyc": "15.1.0",
     "prebuildify": "5.0.1",
     "prebuildify-cross": "5.0.0",


### PR DESCRIPTION
Two problems to fix with this one
- our rpi arm64 isn't working possibly because our libc is too new, so we'll target the lts of arm64, worked for [level](https://github.com/Level/classic-level/pull/71) thankful for [their investigation](https://github.com/Level/classic-level/issues/69)
- our arm64 builds were just broken and wouldn't build so we're fixing that with a variable in our binding.gyp for `openssl_fips`

When this is released it will hopefully fix https://github.com/serialport/node-serialport/issues/2438