### PR TITLE
Remove lowLatency from Linux specific PortStatus

### DIFF
--- a/lib/linux.ts
+++ b/lib/linux.ts
@@ -19,10 +19,6 @@ export interface LinuxOpenOptions extends OpenOptions {
   // * @param {Boolean} [options.lowLatency=false] flag for lowLatency mode on Linux
 }
 
-export interface LinuxPortStatus extends PortStatus {
-  lowLatency: boolean
-}
-
 export interface LinuxSetOptions extends SetOptions {
   /** Low latency mode */
   lowLatency?: boolean
@@ -172,7 +168,7 @@ export class LinuxPortBinding implements BindingPortInterface {
     await asyncUpdate(this.fd, options)
   }
 
-  async set(options: LinuxSetOptions): Promise<void> {
+  async set(options: SetOptions): Promise<void> {
     if (!options || typeof options !== 'object' || Array.isArray(options)) {
 
       throw new TypeError('"options" is not an object')
@@ -184,7 +180,7 @@ export class LinuxPortBinding implements BindingPortInterface {
     await asyncSet(this.fd, options)
   }
 
-  async get(): Promise<LinuxPortStatus> {
+  async get(): Promise<PortStatus> {
     debug('get')
     if (!this.isOpen) {
       throw new Error('Port is not open')


### PR DESCRIPTION
Complementary change to https://github.com/serialport/bindings-interface/pull/37 which includes lowLatency info for all Get Port Status requests (this also matches current behaviour of bindings-cpp).  For systems which do not have a low latency mode FALSE is always returned