### PR TITLE
extract bindings

### DIFF
--- a/lib/load-bindings.ts
+++ b/lib/load-bindings.ts
@@ -1,9 +1,5 @@
-import nodeGypBuild from 'node-gyp-build'
 import { promisify } from 'util'
-import { join } from 'path'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const binding = nodeGypBuild(join(__dirname, '../')) as any
+import { binding } from './serialport-bindings'
 
 export const asyncClose = binding.close ? promisify(binding.close) : async () => { throw new Error('"binding.close" Method not implemented')}
 export const asyncDrain = binding.drain ? promisify(binding.drain) : async () => { throw new Error('"binding.drain" Method not implemented')}

--- a/lib/poller.ts
+++ b/lib/poller.ts
@@ -1,10 +1,9 @@
 import debug from 'debug'
 import { EventEmitter } from 'events'
-import { join } from 'path'
-import nodeGypBuild from 'node-gyp-build'
 import { BindingsError } from './errors'
+import { binding } from './serialport-bindings'
 
-const { Poller: PollerBindings } = nodeGypBuild(join(__dirname, '../')) as { Poller: PollerClass }
+const { Poller: PollerBindings } = binding as { Poller: PollerClass }
 const logger = debug('serialport/bindings-cpp/poller')
 
 interface PollerClass {

--- a/lib/serialport-bindings.ts
+++ b/lib/serialport-bindings.ts
@@ -1,0 +1,5 @@
+import { join } from 'path'
+import nodeGypBuild from 'node-gyp-build'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const binding = nodeGypBuild(join(__dirname, '../')) as any


### PR DESCRIPTION
Hello,

I have a use case where size of an application is important, I'd like to webpack as much as possible. The problematic part is related *.node files, I found a potential solution, example with sqlite: 

```
externals: {
    './sqlite3-binding.js':       'commonjs ./node_sqlite3.node',
}
```

I can replace sqlite3-binding.js [1] with *.node, then I copy node_sqlite3.node to the main application folder. I'd like to try something similar with the serialport. However, it is slightly more complicated since serialport doesn't have single import file. This PR is an attempt to fix the problem.

[1] https://github.com/TryGhost/node-sqlite3/blob/master/lib/sqlite3-binding.js