### PR TITLE
fix: infinite recursion in unix-read

### DIFF
--- a/lib/unix-read.ts
+++ b/lib/unix-read.ts
@@ -39,9 +39,6 @@ export const unixRead = async ({
 
   try {
     const { bytesRead } = await fsReadAsync(binding.fd, buffer, offset, length, null)
-    if (bytesRead === 0) {
-      return unixRead({ binding, buffer, offset, length, fsReadAsync })
-    }
     logger('Finished read', bytesRead, 'bytes')
     return { bytesRead, buffer }
   } catch (err) {


### PR DESCRIPTION
Fixes #162 

According to man 2 read:

> On success, the number of bytes read is returned (zero indicates end of file)...

According to [node fs](https://nodejs.org/api/fs.html#fsreadfd-buffer-offset-length-position-callback):

> If the file is not modified concurrently, the end-of-file is reached when the number of bytes read is zero.

If I understand this correctly (maybe there are some edge cases in the serialport read API?), we should never recurse if read returns zero.

Also, the @serialport/stream package (correctly) contains checks for zero-sized reads [here](https://github.com/serialport/node-serialport/blob/12b4c15a93aa8ed66f9f793a83a52bd82181efc6/packages/stream/lib/index.ts#L306), which could never be the case if we keep recursing on zero.

I had the problems described in #162 with a USB serial port (/dev/ttyUSB0). When I unplugged it during runtime, my program went into this infinite recursion and crashed due to memory. With this fix, it worked as expected.