### PR TITLE
Fix single character reads on windows

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -453,6 +453,10 @@ void __stdcall ReadIOCompletion(DWORD errorCode, DWORD bytesTransferred, OVERLAP
     baton->bytesRead += bytesTransferred;
     baton->offset += bytesTransferred;
   }
+  if (!baton->bytesToRead) {
+    baton->complete = true;
+    return;
+  }
 
   // ReadFileEx and GetOverlappedResult retrieved only 1 byte. Read any additional data in the input
   // buffer. Set the timeout to MAXDWORD in order to disable timeouts, so the read operation will


### PR DESCRIPTION
I have a project using `@serialport/bindings-cpp` that works without issues on MacOS and Linux, but on windows every read fails with 

```
[Error: Reading from COM port (ReadFile): Unknown error code 1784]
```

The device I'm talking to has a binary protocol, and all exchanges begin with a single character write to the device, a single character response from the device, and then further, longer exchanges. The single character read always fails.

This is because `ReadThread` does a single character read using `ReadFileEx`, and then, unconditionally reads "the rest of the data" using `ReadFile`. But in the case of a single character read there is no "rest of the data". This pull request fixes it by checking for no more data before issuing the `ReadFile`.

I don't know how to write a test that would fail without the fix.