### PR TITLE
Install setuptools on macos workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
+      - if: matrix.os == 'macos-11'
+        run: sudo -H pip install setuptools
       - if: matrix.node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
           - { os: ubuntu-latest, arch: x64 }
           - { os: windows-2019, arch: x64 }
     steps:
+    - if: matrix.config.os == 'macos-latest'
+      run: sudo -H pip install setuptools
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
         config:
           # arch isn't used and we have no way to use it currently
-          - { os: macos-latest, arch: x64 }
+          - { os: macos-11, arch: x64 }
           - { os: ubuntu-latest, arch: x64 }
           - { os: windows-2019, arch: x64 }
     steps:
-    - if: matrix.config.os == 'macos-latest'
+    - if: matrix.config.os == 'macos-11'
       run: sudo -H pip install setuptools
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
Macos workflows are currently broken because the hosts no longer have some key tools for some reason.

This PR fixes the build and test macos flows