### PR TITLE
List Serial Ports on i.MX boards (ttymxc*) and Nvidia (ttyGS*, ttyTCU*, ttyTHS*)

### DIFF
--- a/lib/linux-list.ts
+++ b/lib/linux-list.ts
@@ -4,7 +4,7 @@ import { ReadlineParser } from '@serialport/parser-readline'
 
 // get only serial port names
 function checkPathOfDevice(path: string) {
-  return /(tty(S|WCH|ACM|USB|AMA|MFD|O|XRUSB)|rfcomm)/.test(path) && path
+  return /(tty(S|WCH|ACM|USB|AMA|MFD|O|XRUSB|mxc|GS|TCU|THS)|rfcomm)/.test(path) && path
 }
 
 function propName(name: string) {


### PR DESCRIPTION
Some serial ports on SBCs from Nvidia and NXP i.MX6, i.MX7, i.MX8 SOCs were being filtered out.
This adds more items to the list.