### PR TITLE
Update node-gyp-build to fix windows i386 build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@serialport/parser-readline": "11.0.0",
         "debug": "4.3.4",
         "node-addon-api": "7.0.0",
-        "node-gyp-build": "4.6.0"
+        "node-gyp-build": "4.8.1"
       },
       "devDependencies": {
         "@semantic-release/exec": "6.0.3",
@@ -8309,9 +8309,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -21311,9 +21311,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw=="
     },
     "node-preload": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@serialport/parser-readline": "11.0.0",
     "debug": "4.3.4",
     "node-addon-api": "7.0.0",
-    "node-gyp-build": "4.6.0"
+    "node-gyp-build": "4.8.1"
   },
   "devDependencies": {
     "@semantic-release/exec": "6.0.3",


### PR DESCRIPTION
Hello,

Thank you for your work on this project.

This PR updates `node-gyp-build` to `v4.8.1` to fix a bug preventing builds for Windows i386 (see https://github.com/prebuild/node-gyp-build/pull/69).

Thanks