### PR TITLE
Support for workers

### DIFF
--- a/src/serialport_win.h
+++ b/src/serialport_win.h
@@ -19,10 +19,10 @@ struct WriteBaton {
   size_t bufferLength = 0;
   size_t offset = 0;
   size_t bytesWritten = 0;
-  void* hThread = nullptr;
+  std::thread nativeThread;
   bool complete = false;
   Napi::ObjectReference buffer;
-	Napi::FunctionReference callback;
+	Napi::ThreadSafeFunction tsfn; 
   int result = 0;
   char errorString[ERROR_STRING_SIZE];
 };
@@ -37,10 +37,11 @@ struct ReadBaton {
   size_t bytesRead = 0;
   size_t bytesToRead = 0;
   size_t offset = 0;
-  void* hThread = nullptr;
-	Napi::FunctionReference callback;
+  
+  std::thread nativeThread;
   bool complete = false;
   char errorString[ERROR_STRING_SIZE];
+  Napi::ThreadSafeFunction tsfn; 
 };
 
 Napi::Value Read(const Napi::CallbackInfo& info);
@@ -91,3 +92,4 @@ struct ListBaton : public Napi::AsyncWorker {
 };
 
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_WIN_H_
+  


### PR DESCRIPTION
I am contributing to this project by creating a pull request. Since I am not a native English speaker, I apologize for any potential grammatical errors. Additionally, I am not deeply experienced in C++, so if there are any technical issues or poor implementations in my code, I would greatly appreciate your feedback.

In this submission, my primary goal is to ensure the smooth operation of the `node-serialport` module within a worker. To achieve this, I replaced the use of `libuv` with `ThreadSafeFunction`.

> Also, please accept my apologies for the previous erroneous pull request. I regret my mistake and feel sorry for my careless action.