### PR TITLE
fix build for windows ia32

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,7 @@
     'conditions': [
       ['OS=="win"',
         {
-          'defines': ['CHECK_NODE_MODULE_VERSION'],
+          'defines': ['CHECK_NODE_MODULE_VERSION', 'NOMINMAX'],
           'sources': [
             'src/serialport_win.cpp'
           ],


### PR DESCRIPTION
When building my electron app with @serialport/bindincs-cpp, I had an error on windows (same as this one : https://github.com/prebuild/node-gyp-build/issues/70) 

It is fixed with this PR, following this comment https://github.com/electron/electron/issues/40760#issuecomment-1979048889