### PR TITLE
Remove unused import of windows.h

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -5,7 +5,6 @@
 #include <list>
 #include <vector>
 #include <string.h>
-#include <windows.h>
 #include <Setupapi.h>
 #include <initguid.h>
 #include <devpkey.h>


### PR DESCRIPTION
Fixes #199 by not including the header with offending `min`/`max` macros.
Alternative fix to #208.