### PR TITLE
Friendly name support for all platforms

### DIFF
--- a/lib/bindings.test.ts
+++ b/lib/bindings.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { assert, shouldReject } from '../test/assert'
 import { makeTestFeature } from '../test/makeTestFeature'
-import { BindingInterface, OpenOptions, PortInfo, SetOptions } from '@serialport/bindings-interface'
+import { BindingInterface, OpenOptions, PortInfo, SetOptions } from '@noelneu/bindings-interface'
 import { autoDetect } from './index'
 import { MockBinding } from '@serialport/binding-mock'
 import { BindingsError } from './errors'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/debug": "4.1.12",
         "@types/mocha": "10.0.10",
         "@types/node": "22.13.8",
+        "@types/sinon": "^17.0.4",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "cc": "3.0.1",
@@ -2165,6 +2166,23 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/debug": "4.1.12",
     "@types/mocha": "10.0.10",
     "@types/node": "22.13.8",
+    "@types/sinon": "^17.0.4",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "cc": "3.0.1",

--- a/src/darwin_list.h
+++ b/src/darwin_list.h
@@ -14,6 +14,7 @@ void setIfNotEmpty(Napi::Object item, std::string key, const char *value);
 struct ListResultItem {
   std::string path;
   std::string manufacturer;
+  std::string friendlyName;
   std::string serialNumber;
   std::string pnpId;
   std::string locationId;
@@ -38,6 +39,7 @@ struct ListBaton : public Napi::AsyncWorker {
 
       setIfNotEmpty(item, "path", (*it)->path.c_str());
       setIfNotEmpty(item, "manufacturer", (*it)->manufacturer.c_str());
+      setIfNotEmpty(item, "friendlyName", (*it)->friendlyName.c_str());
       setIfNotEmpty(item, "serialNumber", (*it)->serialNumber.c_str());
       setIfNotEmpty(item, "pnpId", (*it)->pnpId.c_str());
       setIfNotEmpty(item, "locationId", (*it)->locationId.c_str());
@@ -56,6 +58,7 @@ typedef struct SerialDevice {
     char vendorId[MAXPATHLEN];
     char productId[MAXPATHLEN];
     char manufacturer[MAXPATHLEN];
+    char friendlyName[MAXPATHLEN];
     char serialNumber[MAXPATHLEN];
 } stSerialDevice;
 

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -871,9 +871,9 @@ void ListBaton::Execute() {
                                          reinterpret_cast<PBYTE>(szBuffer), sizeof(szBuffer), &dwSize)) {
       locationId = wcsdup(szBuffer);
     }
-    if (SetupDiGetDeviceRegistryPropertyW(hDevInfo, &deviceInfoData,
-                                         SPDRP_FRIENDLYNAME, &dwPropertyRegDataType,
-                                         reinterpret_cast<PBYTE>(szBuffer), sizeof(szBuffer), &dwSize)) {
+    if (SetupDiGetDevicePropertyW(hDevInfo, &deviceInfoData, 
+                                 &DEVPKEY_Device_BusReportedDeviceDesc, &dwPropertyRegDataType, 
+                                 reinterpret_cast<PBYTE>(szBuffer), sizeof(szBuffer), &dwSize, 0)) {
       friendlyName = wcsdup(szBuffer);
     }
     if (SetupDiGetDeviceRegistryPropertyW(hDevInfo, &deviceInfoData,


### PR DESCRIPTION
This adds / fixes friendly name support for all platforms.

- Windows:
    Friendly names were already supported, but it would just show the generic name (like "USB Serial Device" or "USB Serial Port"). 
    This was changed to showing the device string (in USB CDC devices) if available.

- Mac:
  Friendly name support was added, showing the USB device string if available.

- Linux:
  As for Mac.
  In addition, filtering for active serial ports was added, whereas previously a long list of inactive ttys was returned.
This ensures behavior that is consistent with the other platforms.
  