### PR TITLE
fix: switch Windows runner image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           # arch isn't used and we have no way to use it currently
           - { os: macos-latest, arch: x64 }
           - { os: ubuntu-latest, arch: x64 }
-          - { os: windows-2019, arch: x64 }
+          - { os: windows-latest, arch: x64 }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3


### PR DESCRIPTION
Switch to a current github windows image.
Previously, all CI test runs would fail with a message like:
> Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045