### PR TITLE
Upgrade C++ linting to use modern cpplint tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v5
       with:
         node-version: 20
     - run: npm ci
@@ -25,10 +25,10 @@ jobs:
           # arch isn't used and we have no way to use it currently
           - { os: macos-latest, arch: x64 }
           - { os: ubuntu-latest, arch: x64 }
-          - { os: windows-2019, arch: x64 }
+          - { os: windows-latest, arch: x64 }
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "node-gyp-build": "4.8.4"
       },
       "devDependencies": {
+        "@cpplint/cli": "^0.1.0",
         "@semantic-release/exec": "6.0.3",
         "@serialport/binding-mock": "10.2.2",
         "@types/chai": "5.0.1",
@@ -26,7 +27,6 @@
         "@types/node": "22.13.8",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
-        "cc": "3.0.1",
         "chai": "5.2.0",
         "chai-subset": "1.6.0",
         "esbuild": "0.25.5",
@@ -357,6 +357,108 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cpplint/cli": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cli/-/cli-0.1.0.tgz",
+      "integrity": "sha512-Tt9CL0yKbBox3COOJMzF8jQhCPG4IAOgf9/d35aC8mxPJijZA26wThCASJU0hjbEOFjYmC6qcF1tIwtxlDO5CA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "cpplint": "bin/cpplint"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@cpplint/cpplint-cpp-darwin": "0.1.0",
+        "@cpplint/cpplint-cpp-linux-arm64": "0.1.0",
+        "@cpplint/cpplint-cpp-linux-x64": "0.1.0",
+        "@cpplint/cpplint-cpp-win32-arm64": "0.1.0",
+        "@cpplint/cpplint-cpp-win32-x64": "0.1.0"
+      }
+    },
+    "node_modules/@cpplint/cpplint-cpp-darwin": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cpplint-cpp-darwin/-/cpplint-cpp-darwin-0.1.0.tgz",
+      "integrity": "sha512-kiySz6KfkElozBcBH6ckvSmCkfPc64C4eBIf5nQZdbscWS5XI/iwTRygrI8qGlA9G9AH6xad+VsM8V3cRosqWA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cpplint/cpplint-cpp-linux-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cpplint-cpp-linux-arm64/-/cpplint-cpp-linux-arm64-0.1.0.tgz",
+      "integrity": "sha512-9iGPbFhW3mmIzE/Zb3JgHt7V5xKaeVPf/N1g7pxhzb1i7ktOwyRS24ICeisnbaoKAYzk6jXCQFVWqn9MnRy3sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cpplint/cpplint-cpp-linux-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cpplint-cpp-linux-x64/-/cpplint-cpp-linux-x64-0.1.0.tgz",
+      "integrity": "sha512-b1k8UquCKeLSgdY+tRVYZR+95Gfu6pZMsSQzUcjXJf/rI7+6Ub2CsMMdfKtKCA9cmF9YestVQJK2D72MCHM1/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cpplint/cpplint-cpp-win32-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cpplint-cpp-win32-arm64/-/cpplint-cpp-win32-arm64-0.1.0.tgz",
+      "integrity": "sha512-UBStmMoIyylGsdXTIMDaNR1C86bpZ7egBCAbRnPKOSUoDhXmT1FL53GLBEdnGU51Z8SvZWa384FeQJVk3tGNOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cpplint/cpplint-cpp-win32-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@cpplint/cpplint-cpp-win32-x64/-/cpplint-cpp-win32-x64-0.1.0.tgz",
+      "integrity": "sha512-NCWJ3rfc3QDgmqIbu1HXHhEBpJpVOmsFMstwTM8G19ds7haC8ercTfg4Vc7x9efuAxhJWLBeJe/FdO4uqSWiJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3573,19 +3675,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cc": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deglob": "^4.0.1",
-        "pkg-conf": "^3.1.0",
-        "python-shell": "^2.0.3"
-      },
-      "bin": {
-        "cpplint": "bin/cpplint.js"
-      }
-    },
     "node_modules/chai": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
@@ -4133,14 +4222,6 @@
         }
       }
     },
-    "node_modules/debug-log": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "dev": true,
@@ -4202,19 +4283,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deglob": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      }
     },
     "node_modules/deps-sort": {
       "version": "2.0.1",
@@ -5361,11 +5429,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "2.1.0",
@@ -11783,146 +11846,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pkg-conf": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/find-up": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/load-json-file": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^4.0.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0",
-        "type-fest": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/locate-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/p-limit": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/p-locate": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/p-try": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/parse-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/pify": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pkg-conf/node_modules/type-fest": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-config": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/prebuildify": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-6.0.1.tgz",
@@ -12104,14 +12027,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/python-shell": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/querystring": {
@@ -13998,11 +13913,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/uniq": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "node-gyp-build": "4.8.4"
   },
   "devDependencies": {
+    "@cpplint/cli": "^0.1.0",
     "@semantic-release/exec": "6.0.3",
     "@serialport/binding-mock": "10.2.2",
     "@types/chai": "5.0.1",
@@ -34,7 +35,6 @@
     "@types/node": "22.13.8",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
-    "cc": "3.0.1",
     "chai": "5.2.0",
     "chai-subset": "1.6.0",
     "esbuild": "0.25.5",
@@ -61,7 +61,7 @@
     "prebuildify-cross": "prebuildify-cross --napi --target 20.0.0 --force --strip --verbose",
     "rebuild": "node-gyp rebuild",
     "format": "eslint lib test bin --fix",
-    "lint": "eslint lib test bin && cc --verbose",
+    "lint": "eslint lib test bin && cpplint src/*.cpp src/*.h",
     "test": "nyc --reporter lcov --reporter text mocha",
     "test:arduino": "TEST_PORT=$(./bin/find-arduino.ts) npm test",
     "test:watch": "mocha -w",
@@ -73,17 +73,6 @@
   },
   "license": "MIT",
   "gypfile": true,
-  "cc": {
-    "filter": [
-      "legal/copyright",
-      "build/include"
-    ],
-    "files": [
-      "src/*.cpp",
-      "src/*.h"
-    ],
-    "linelength": "120"
-  },
   "binary": {
     "napi_versions": [
       8

--- a/src/CPPLINT.cfg
+++ b/src/CPPLINT.cfg
@@ -1,0 +1,21 @@
+set noparent
+
+linelength=120
+
+filter=-build/header_guard
+filter=-build/include_order
+filter=-build/include_subdir
+filter=-legal/copyright
+filter=-readability/todo
+filter=-runtime/explicit
+filter=-whitespace/blank_line
+filter=-whitespace/braces
+filter=-whitespace/comma
+filter=-whitespace/comments
+filter=-whitespace/end_of_line
+filter=-whitespace/ending_newline
+filter=-whitespace/indent
+filter=-whitespace/line_length
+filter=-whitespace/newline
+filter=-whitespace/parens
+filter=-whitespace/tab

--- a/src/darwin_list.cpp
+++ b/src/darwin_list.cpp
@@ -1,4 +1,4 @@
-#include "./darwin_list.h"
+#include "darwin_list.h"
 
 #include <IOKit/IOKitLib.h>
 #include <IOKit/IOCFPlugIn.h>
@@ -10,6 +10,7 @@
 #include <IOKit/serial/ioss.h>
 #endif
 
+#include <cstdio>
 #include <string>
 #include <list>
 

--- a/src/darwin_list.h
+++ b/src/darwin_list.h
@@ -22,7 +22,7 @@ struct ListResultItem {
 };
 
 struct ListBaton : public Napi::AsyncWorker {
-  ListBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:ListBaton"), 
+  ListBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:ListBaton"), 
   errorString() {}
   std::list<ListResultItem*> results;
   char errorString[ERROR_STRING_SIZE];

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -1,6 +1,6 @@
 #include <napi.h>
 #include <uv.h>
-#include "./poller.h"
+#include "poller.h"
 
 Poller::Poller (const Napi::CallbackInfo &info) : Napi::ObjectWrap<Poller>(info)
   {

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -1,14 +1,16 @@
-#include "./serialport.h"
+#include "serialport.h"
+#include <cstdio>
+#include <string>
 
 #ifdef __APPLE__
-  #include "./darwin_list.h"
+  #include "darwin_list.h"
 #endif
 
 #ifdef WIN32
   #define strncasecmp strnicmp
-  #include "./serialport_win.h"
+  #include "serialport_win.h"
 #else
-  #include "./poller.h"
+  #include "poller.h"
 #endif
 
 Napi::Value getValueFromObject(Napi::Object options, std::string key) {

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -57,7 +57,7 @@ SerialPortStopBits ToStopBitEnum(double stopBits);
 SerialPortRtsMode ToRtsModeEnum(const Napi::String& str);
 
 struct OpenBaton : public Napi::AsyncWorker {
-  OpenBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:OpenBaton"),
+  OpenBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:OpenBaton"),
   errorString(), path() {}
   char errorString[ERROR_STRING_SIZE];
   char path[1024];
@@ -106,7 +106,7 @@ struct ConnectionOptionsBaton : ConnectionOptions , Napi::AsyncWorker {
 };
 
 struct SetBaton : public Napi::AsyncWorker {
-  SetBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:SetBaton"),
+  SetBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:SetBaton"),
   errorString() {}
   int fd = 0;
   int result = 0;
@@ -128,7 +128,7 @@ struct SetBaton : public Napi::AsyncWorker {
 };
 
 struct GetBaton : public Napi::AsyncWorker {
-  GetBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:GetBaton"),
+  GetBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:GetBaton"),
   errorString() {}
   int fd = 0;
   char errorString[ERROR_STRING_SIZE];
@@ -152,7 +152,7 @@ struct GetBaton : public Napi::AsyncWorker {
 };
 
 struct GetBaudRateBaton : public Napi::AsyncWorker {
-  GetBaudRateBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:GetBaudRateBaton"),
+  GetBaudRateBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:GetBaudRateBaton"),
   errorString() {}
   int fd = 0;
   char errorString[ERROR_STRING_SIZE];
@@ -170,7 +170,7 @@ struct GetBaudRateBaton : public Napi::AsyncWorker {
 };
 
 struct VoidBaton : public Napi::AsyncWorker {
-  VoidBaton(Napi::Function& callback, const char *resource_name) : Napi::AsyncWorker(callback, resource_name),
+  VoidBaton(const Napi::Function& callback, const char *resource_name) : Napi::AsyncWorker(callback, resource_name),
   errorString() {}
   int fd = 0;
   char errorString[ERROR_STRING_SIZE];

--- a/src/serialport_linux.cpp
+++ b/src/serialport_linux.cpp
@@ -1,5 +1,6 @@
 #if defined(__linux__)
 
+#include "serialport_linux.h"
 #include <sys/ioctl.h>
 #include <asm/ioctls.h>
 #include <asm/termbits.h>

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <termios.h>
+#include <cstdio>
 
 #ifdef __APPLE__
 #include <AvailabilityMacros.h>

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -1,5 +1,5 @@
-#include "./serialport.h"
-#include "./serialport_win.h"
+#include "serialport.h"
+#include "serialport_win.h"
 #include <napi.h>
 #include <uv.h>
 #include <list>
@@ -11,6 +11,7 @@
 #include <devpkey.h>
 #include <devguid.h>
 #include <wchar.h>
+#include <string>
 #pragma comment(lib, "setupapi.lib")
 
 #define ARRAY_SIZE(arr)     (sizeof(arr)/sizeof(arr[0]))

--- a/src/serialport_win.h
+++ b/src/serialport_win.h
@@ -61,7 +61,7 @@ struct ListResultItem {
 };
 
 struct ListBaton : public Napi::AsyncWorker {
-  ListBaton(Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:ListBaton"), 
+  ListBaton(const Napi::Function& callback) : Napi::AsyncWorker(callback, "node-serialport:ListBaton"),
   errorString() {}
   std::list<ListResultItem*> results;
   wchar_t errorString[ERROR_STRING_SIZE];


### PR DESCRIPTION
- Switches from [cc](https://www.npmjs.com/package/cc) to [@cpplint/cli](https://www.npmjs.com/package/@cpplint/cli) (I maintain both, but the former will be deprecated/archived soon).

- Ensures compliance with a couple of important new rules:
    - `build/include_what_you_use`
    - `runtime/references`
    
- Adds a standard `CPPLINT.cfg` configuration file with a list of ignored rules, mostly whitespace-related. Getting these to pass is left as a future exerise.

- Finally, in a separate commit, upgrades Windows CI to a supported version (the windows-2019 runner reached EOL on 2025-06-30).
