### PR TITLE
Fix working with CDC-ACM (ttyACMx) / CH347T

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -396,7 +396,7 @@ void SetBaton::Execute() {
     result = ioctl(fd, TIOCCBRK, NULL);
   }
 
-  if (-1 == result) {
+  if (-1 == result && errno != EOPNOTSUPP) {
     snprintf(errorString, sizeof(errorString), "Error: %s, cannot set", strerror(errno));
     this->SetError(errorString);
     return;


### PR DESCRIPTION
Currently, we have a serious problem with all CDC-ACM serial ports. For example, with the very popular USB-to-RS232 adapter **CH347T**:
```
  serialport/stream binding.set had an error [Error: Error: Operation not supported, cannot set] +1ms
```
We cannot set any modem control signals because the **BRK** signal is optional in CDC-ACM implementations.
See the Linux CDC-ACM driver source: https://github.com/torvalds/linux/blob/6fab32bb6508abbb8b7b1c5498e44f0c32320ed5/drivers/usb/class/cdc-acm.c#L930

A good solution is simply to ignore the ioctl error if it's EOPNOTSUPP.
Example: https://github.com/torvalds/linux/blob/2e590d67c2d803d603ac00b85f2fab235df52a1b/drivers/tty/tty_io.c#L2486