### PR TITLE
fix(build): run build for git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig-build.json",
+    "prepare": "npm run build",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --target 20.0.0 --force --strip --verbose",
     "prebuildify-cross": "prebuildify-cross --napi --target 20.0.0 --force --strip --verbose",


### PR DESCRIPTION
Adds a `prepare`  lifecycle script to build `dist/` on git-based installs. For example allows pinning changes like #235 from Git as a package.json override until it is merged/released.