### PR TITLE
fix(unix): prevent close/drain hangs after write timeouts

### DIFF
--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -132,6 +132,11 @@ Napi::Value Close(const Napi::CallbackInfo& info) {
   CloseBaton* baton = new CloseBaton(callback);
   baton->fd = info[0].ToNumber().Int64Value();;
 
+#ifndef WIN32
+  // Mark as closing before queueing worker so in-flight drain workers can exit.
+  markClosingFd(baton->fd);
+#endif
+
   baton->Queue();
   return env.Undefined();
 }

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -199,4 +199,9 @@ struct FlushBaton : VoidBaton {
 
 int setup(int fd, OpenBaton *data);
 int setBaudRate(ConnectionOptions *data);
+
+#ifndef WIN32
+void markClosingFd(int fd);
+void unmarkClosingFd(int fd);
+#endif
 #endif  // PACKAGES_SERIALPORT_SRC_SERIALPORT_H_

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -359,6 +359,12 @@ int setBaudRate(ConnectionOptions *data) {
 }
 
 void CloseBaton::Execute() {
+  // Avoid blocking close() on tty drivers that wait for pending TX.
+  int flags = fcntl(fd, F_GETFL);
+  if (flags != -1) {
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  }
+  tcflush(fd, TCOFLUSH);
 
   if (-1 == close(fd)) {
     snprintf(errorString, sizeof(errorString), "Error: %s, unable to close fd %d", strerror(errno), fd);


### PR DESCRIPTION
While working with #235 (in WSL), I noticed that the Unix serial port implementation could hang on close/drain timeout paths, leaving the process alive after final output.

Particularly, the close path is hardened by setting `O_NONBLOCK`, flushing pending TX (`tcflush(..., TCOFLUSH)`), and then closing the fd. This avoids blocking close behavior after prior write timeouts.

The Linux drain path is made close-aware: `DrainBaton` now checks `TIOCOUTQ` and exits early when close is in progress, rather than continuing to wait in timeout-heavy scenarios.

Close intent is now marked at `Close(...)` API entry (before queueing the close worker), so in-flight drain workers can observe cancellation immediately. This removes a race where worker-pool saturation could delay close and leave timeout-path runs hanging.

**Repros:**

```js
import { autoDetect } from "@serialport/bindings-cpp";

const Binding = autoDetect();
const path = process.argv[2] ?? "/dev/ttyACM0";
const port = await Binding.open({ path, baudRate: 115200 });
const payload = Buffer.alloc(46, 0x55);

function withTimeout(promise, ms, label) {
  return Promise.race([
    promise,
    new Promise((_, reject) => setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)),
  ]);
}

// Repro A: drain-close interaction (drain cancellation + early close-intent timing)
for (let i = 0; i < 7; i++) {
  try {
    await withTimeout(port.write(payload), 3000, `write#${i + 1}`);
    await withTimeout(port.drain(), 3000, `drain#${i + 1}`);
  } catch {
    // intentionally continue stressing timeout path
  }
}

await withTimeout(port.close(), 3000, "close");
console.log("closed cleanly");
// Before this patch: process could linger after this point
```

```js
...

// Repro B: close hardening path (close after timeout-path write, no drain loop)
try {
  await withTimeout(port.write(payload), 3000, "write");
} catch {
  // expected on stressed/non-responsive path
}

await withTimeout(port.close(), 3000, "close");
console.log("closed cleanly");
// Before this patch: close could block/linger on Unix timeout path
```

I also tested equivalent timeout paths on Windows and did not reproduce a similar close/drain lingering issue. I did observe a post-close "GetOverlappedResult: Operation aborted" error event there, but this appears to be separate platform-specific behavior.